### PR TITLE
Fixed wildcard creates not returning an error

### DIFF
--- a/core/src/main/scala/com/ibm/csync/types/Key.scala
+++ b/core/src/main/scala/com/ibm/csync/types/Key.scala
@@ -45,7 +45,10 @@ object Key {
       ResponseCode.InvalidPathFormat.throwIt(s"too long $totalLen ${parts.mkString(".")}")
     }
     val partsSeq = parts map { Part(_) }
-    new Key(partsSeq.collect { case x @ Identifier(_) => x })
+    new Key(partsSeq.collect {
+      case identifier @ Identifier(_) => identifier
+      case _ => ResponseCode.InvalidPathFormat.throwIt("Expected a concrete key, but received a key with a * or #")
+    })
 
   }
 


### PR DESCRIPTION
Resolves #39
Proposed Changes:
*  Key Object now returns an error if you try to create a key with "*" or "#"
*  Move creation of key in Pub around so that they are only created when they are needed and we know we have a concrete key.
*  Added a new test for this case and updated the tests with slight style improvements
DCO1.1 Signed-off-by: Thomas Boop <tgboop@us.ibm.com>